### PR TITLE
Add ability to pass text content other than a file path

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,3 +1,8 @@
+2.1.0 / 2015-06-18
+==================
+
+  * Add ability to pass text content other than a file path
+
 2.0.0 / 2015-01-27
 ==================
 

--- a/lib/express-zip.js
+++ b/lib/express-zip.js
@@ -26,7 +26,7 @@ exports.options = { level: 1 };
  * "save as" `filename` (default is attachment.zip), and then call `cb`
  * when finished.
  *
- * @param {Array} files { name: <name>, path: <path> }
+ * @param {Array} files { name: <name>, path: <path> } or { name: <name>, content: <content> }
  * @param {String|Function} filename that will be shown in "save as" dialog
  * @param {Function} cb(err, bytesZipped) optional
  * @return {undefined}
@@ -52,7 +52,8 @@ res.zip = function(files, filename, cb) {
   zip.pipe(this); // res is a writable stream
 
   var addFile = function(file, cb) {
-    zip.entry(fs.createReadStream(file.path), { name: file.name }, cb);
+    var body = file.path ? fs.createReadStream(file.path) : file.content;
+    zip.entry(body, { name: file.name }, cb);
   };
 
   async.forEachSeries(files, addFile, function(err) {

--- a/package.json
+++ b/package.json
@@ -1,11 +1,15 @@
 {
   "name": "express-zip",
   "description": "stream multiple files to the browser as a single zip, in pure node.",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "author": {
     "name": "Craig McDonald (thrackle)",
     "email": "oss@thrackle.com"
   },
+  "contributors": [{
+    "name": "Renato Gama",
+    "email": "renatoargh@gmail.com"
+  }],
   "dependencies": {
     "async": "0.9.0",
     "zip-stream": "0.5.0"

--- a/test/index.js
+++ b/test/index.js
@@ -28,6 +28,13 @@ function testExpressVersion(version) {
         ], 'test2.zip');
       });
 
+      app.get('/test/3', function(req, res) {
+        res.zip([
+          { content: 'text content', name: 'data1.txt' },
+          { content: 'more text', name: 'data2.txt' }
+        ], 'test3.zip');
+      });
+
       server = app.listen(8383)
     })
 


### PR DESCRIPTION
First, thanks for your work. This is a feature suggestion, not sure how to implement valuable tests. 

My use case for this feature is that I have, say, 100 xml files in a database that I want to allow users to download. Having the ability to zip them in memory is better than creating files in disk. To illustrate better:

``` javascript
var records = database.select('*').from('table'); // this is actually async
res.zip(records.map(function(record) {
    return {
        name: record.fileName + '.xml',
        content: record.xml
    };
});
```
