### PR TITLE
Changed callback from res.zip to actually get called once all entries are added

### DIFF
--- a/lib/express-zip.js
+++ b/lib/express-zip.js
@@ -57,8 +57,7 @@ res.zip = function(files, filename, cb) {
 
   async.forEachSeries(files, addFile, function(err) {
     if (err) return cb(err);
-    zip.finalize(function(bytesZipped) {
-      cb(null, bytesZipped);
-    });
+    zip.finalize();
+    cb(null);
   });
 };

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   },
   "devDependencies": {
     "mocha": "*",
+    "should": "*",
     "superagent": "*",
     "express": "2"
   },

--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
   },
   "devDependencies": {
     "mocha": "*",
-    "chai": "*",
     "superagent": "*",
     "express": "2"
   },

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "zip-stream": "0.5.0"
   },
   "devDependencies": {
-    "mocha": "*",
+    "mocha": "2.2.5",
     "should": "*",
     "superagent": "*",
     "express": "2"

--- a/test/index.js
+++ b/test/index.js
@@ -35,7 +35,7 @@ function testExpressVersion(version) {
       it('should response valid content-type', function(done) {
         request
           .get('http://127.0.0.1:8383/test/1')
-          .end(function(res) {
+          .end(function(err,res) {
             expect(res.headers['content-type']).to.match(/^application\/zip/);
             done();
           });
@@ -44,7 +44,7 @@ function testExpressVersion(version) {
       it('should response valid content-disposition', function(done) {
         request
           .get('http://127.0.0.1:8383/test/1')
-          .end(function(res) {
+          .end(function(err,res) {
             expect(res.headers['content-disposition']).to.match(/^attachment; filename="attachment.zip"/);
             done();
           });
@@ -53,7 +53,7 @@ function testExpressVersion(version) {
       it('can pass filename', function(done) {
         request
           .get('http://127.0.0.1:8383/test/2')
-          .end(function(res) {
+          .end(function(err,res) {
             expect(res.headers['content-disposition']).to.match(/^attachment; filename="test2.zip"/);
             done();
           });

--- a/test/index.js
+++ b/test/index.js
@@ -1,7 +1,7 @@
 var expressFactory = require('./express-factory');
 var request = require('superagent');
 var zip = require('../');
-var expect = require('chai').expect;
+var should = require('should');
 
 testExpressVersion(2)
 testExpressVersion(3)
@@ -36,7 +36,8 @@ function testExpressVersion(version) {
         request
           .get('http://127.0.0.1:8383/test/1')
           .end(function(err,res) {
-            expect(res.headers['content-type']).to.match(/^application\/zip/);
+            should.exist(res);
+            res.headers['content-type'].should.match(/^application\/zip/);
             done();
           });
       });
@@ -45,7 +46,8 @@ function testExpressVersion(version) {
         request
           .get('http://127.0.0.1:8383/test/1')
           .end(function(err,res) {
-            expect(res.headers['content-disposition']).to.match(/^attachment; filename="attachment.zip"/);
+            should.exist(res);
+            res.headers['content-disposition'].should.match(/^attachment; filename="attachment.zip"/);
             done();
           });
       });
@@ -54,7 +56,8 @@ function testExpressVersion(version) {
         request
           .get('http://127.0.0.1:8383/test/2')
           .end(function(err,res) {
-            expect(res.headers['content-disposition']).to.match(/^attachment; filename="test2.zip"/);
+            should.exist(res);
+            res.headers['content-disposition'].should.match(/^attachment; filename="test2.zip"/);
             done();
           });
       });


### PR DESCRIPTION
`zipstream.finalize` had a callback, but `zip-stream.finalize` does not, so it seems as though this callback never actually gets called. Moving it out of the `zip.finalize` call is an improvement, although not the best solution as it seems like the underlying `stream.end()` call takes a callback to be called once the stream is actually closed.