### PR TITLE
call cb after zip.finalize()'s synchronous execution

### DIFF
--- a/lib/express-zip.js
+++ b/lib/express-zip.js
@@ -57,8 +57,7 @@ res.zip = function(files, filename, cb) {
 
   async.forEachSeries(files, addFile, function(err) {
     if (err) return cb(err);
-    zip.finalize(function(bytesZipped) {
-      cb(null, bytesZipped);
-    });
+    zip.finalize();
+    cb(null, zip.getBytesWritten());
   });
 };


### PR DESCRIPTION
currently, the `cb` passed to `res.zip` is never called

according to [ZipStream's documentation](http://archiverjs.com/zip-stream/ZipStream.html#finalize), `#finalize()` takes no arguments, and as @pdspicer pointed out in https://github.com/thrackle/express-zip/pull/7, the method is synchronous.

in this PR, `cb` is successfully called after `zip.finalize()'s` synchronous execution.

thx for this module -- it's very helpful :)