### PR TITLE
Fix for non-ascii filenames

### DIFF
--- a/lib/express-zip.js
+++ b/lib/express-zip.js
@@ -46,7 +46,7 @@ res.zip = function(files, filename, cb) {
   cb = cb || function() {};
 
   this.header('Content-Type', 'application/zip');
-  this.header('Content-Disposition', 'attachment; filename="' + filename + '"');
+  this.header('Content-Disposition', 'attachment;filename*=UTF-8\'\''+ encodeURIComponent(filename));
 
   var zip = zipstream(exports.options);
   zip.pipe(this); // res is a writable stream


### PR DESCRIPTION
Fixed "The header content contains invalid characters" error thrown by Express on non-ascii filenames according to:
https://tools.ietf.org/html/rfc6266#section-6