### PR TITLE
Bump minor deps

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ build:
 	@cd test/express-factory/4; npm install --loglevel error
 
 test:
-	@mocha
+	@./node_modules/mocha/bin/mocha
 
 publish: test
 	npm publish

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   }],
   "dependencies": {
     "async": "0.9.0",
-    "zip-stream": "^0.5.2"
+    "zip-stream": "0.5.2"
   },
   "devDependencies": {
     "mocha": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "express-zip",
   "description": "stream multiple files to the browser as a single zip, in pure node.",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "author": {
     "name": "Craig McDonald (thrackle)",
     "email": "oss@thrackle.com"

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   }],
   "dependencies": {
     "async": "0.9.0",
-    "zip-stream": "0.5.0"
+    "zip-stream": "2.1.2"
   },
   "devDependencies": {
     "mocha": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "url": "https://github.com/pdspicer"
   }],
   "dependencies": {
-    "async": "0.9.0",
+    "async": "0.9.2",
     "zip-stream": "0.5.2"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   }],
   "dependencies": {
     "async": "0.9.0",
-    "zip-stream": "2.1.2"
+    "zip-stream": "^0.5.2"
   },
   "devDependencies": {
     "mocha": "2.1.0",

--- a/test/express-factory/2/package.json
+++ b/test/express-factory/2/package.json
@@ -1,6 +1,6 @@
 {
   "name": "express2-factory",
   "dependencies": {
-    "express": "^2.5.11"
+    "express": "~2.5.11"
   }
 }

--- a/test/express-factory/2/package.json
+++ b/test/express-factory/2/package.json
@@ -1,6 +1,6 @@
 {
   "name": "express2-factory",
   "dependencies": {
-    "express": "~2.5.11"
+    "express": "^2.5.11"
   }
 }

--- a/test/express-factory/3/package.json
+++ b/test/express-factory/3/package.json
@@ -1,6 +1,6 @@
 {
   "name": "express3-factory",
   "dependencies": {
-    "express": "^3.21.2"
+    "express": "~3.21.2"
   }
 }

--- a/test/express-factory/3/package.json
+++ b/test/express-factory/3/package.json
@@ -1,6 +1,6 @@
 {
   "name": "express3-factory",
   "dependencies": {
-    "express": "~3.19.1"
+    "express": "^3.21.2"
   }
 }

--- a/test/express-factory/4/package.json
+++ b/test/express-factory/4/package.json
@@ -1,6 +1,6 @@
 {
   "name": "express3-factory",
   "dependencies": {
-    "express": "~4.11.1"
+    "express": "^4.17.1"
   }
 }

--- a/test/express-factory/4/package.json
+++ b/test/express-factory/4/package.json
@@ -1,6 +1,6 @@
 {
   "name": "express3-factory",
   "dependencies": {
-    "express": "^4.17.1"
+    "express": "~4.17.1"
   }
 }


### PR DESCRIPTION
Bumping minor and patch version for deps, and publishing a new version.  The next release will drop support for versions of node that are no longer supported, so this is a last update for package users on (very) old versions of node.